### PR TITLE
Addressing issue for jline/jansi where same name for dll is used regardless of bit model

### DIFF
--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java
@@ -209,6 +209,7 @@ public class Library {
             if( version !=null) {
                 libName += "-" + version;
             }
+            libName += "-" + getBitModel();
             
             if( customPath!=null ) {
                 // Try to extract it to the custom path...


### PR DESCRIPTION
Adding bit model to the name of the extracted library to support hosts running both 32 and 64 bits JVM. See Issue #2.

(this is related to https://issues.scala-lang.org/browse/SI-4703)
