### PR TITLE
Allow to also use generate mojo with existing native src files

### DIFF
--- a/maven-hawtjni-plugin/src/main/java/org/fusesource/hawtjni/maven/GenerateMojo.java
+++ b/maven-hawtjni-plugin/src/main/java/org/fusesource/hawtjni/maven/GenerateMojo.java
@@ -60,6 +60,13 @@ public class GenerateMojo extends AbstractMojo {
     protected MavenProject project;
 
     /**
+     * The directory where the native source files are located.
+     *
+     * @parameter
+     */
+    private File nativeSourceDirectory;
+
+    /**
      * The directory where the generated native source files are located.
      * 
      * @parameter default-value="${project.build.directory}/generated-sources/hawtjni/native-src"
@@ -169,8 +176,20 @@ public class GenerateMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
     	cli.verbose = verbose;
     	cli.log = getLog();
-        generateNativeSourceFiles();
-        generateBuildSystem(); 
+        if (nativeSourceDirectory == null) {
+            generateNativeSourceFiles();
+        } else {
+            copyNativeSourceFiles();
+        }
+        generateBuildSystem();
+    }
+
+    private void copyNativeSourceFiles() throws MojoExecutionException {
+        try {
+            FileUtils.copyDirectory(nativeSourceDirectory, generatedNativeSourceDirectory);
+        } catch (Exception e) {
+            throw new MojoExecutionException("Copy of Native source failed: "+e, e);
+        }
     }
 
     private void generateNativeSourceFiles() throws MojoExecutionException {
@@ -295,7 +314,7 @@ public class GenerateMojo extends AbstractMojo {
         if( !filter ) {
             return new FilterWrapper[0];
         }
-        
+
         final String startExp = "@";
         final String endExp = "@";
         final String escapeString = "\\";


### PR DESCRIPTION
This allows to use the maven plugin also with existing JNI code while not using hawtjni to generate it at all.

We would love to make use of this in the netty project to ship our native code ASAP. So it would be awesome if you would consider to include this patch and do a release :)

Thanks for your hard work on this project. It really rocks!

Here you can see the change in action:
https://github.com/netty/netty/blob/native-hawtjni/transport-native-epoll/pom.xml
