### PR TITLE
Version bumps and markup fixes necessary for building on JDK8

### DIFF
--- a/hawtjni-generator/pom.xml
+++ b/hawtjni-generator/pom.xml
@@ -40,17 +40,17 @@
     <dependency>
       <artifactId>xbean-finder</artifactId>    
       <groupId>org.apache.xbean</groupId>
-      <version>3.6</version>
+      <version>3.18</version>
     </dependency>
     <dependency>
-      <groupId>asm</groupId>
+      <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>3.1</version>
+      <version>5.0.3</version>
     </dependency>
     <dependency>
-      <groupId>asm</groupId>
+      <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <version>3.1</version>
+      <version>5.0.3</version>
     </dependency>
     
     <!-- 

--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/ArgFlag.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/ArgFlag.java
@@ -33,7 +33,7 @@ public enum ArgFlag {
     
     /**
      * Indicate that GetPrimitiveArrayCritical() should be used instead 
-     * of Get<PrimitiveType>ArrayElements() when transferring array of 
+     * of Get&lt;PrimitiveType&gt;ArrayElements() when transferring array of 
      * primitives from/to C. This is an optimization to avoid copying 
      * memory and must be used carefully. It is ok to be used in
      * MoveMemory() and memmove() natives. 

--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/MethodFlag.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/MethodFlag.java
@@ -50,7 +50,7 @@ public enum MethodFlag {
     /**
      * Indicate that the native method represents a structure global 
      * variable and the address of it should be returned to Java. This is 
-     * done by prepending &.
+     * done by prepending &amp;.
      */
     ADDRESS,
     

--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/NativeStats.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/NativeStats.java
@@ -24,18 +24,18 @@ import java.util.Map.Entry;
  * <li> Compile the native libraries defining the NATIVE_STATS flag.</li>
  * <li> Add the following code around the sections of
  *      interest to dump the native calls done in that section. 
- *      <code><pre>
+ *      <pre>
  *      StatsInterface si = MyFooStatsInterface.INSTANCE;
  *      NativeStats stats = new NativeStats(si); 
  *      ... // your code
  *      stats.diff().dump(System.out);
- *      </pre></code>
+ *      </pre>
  * </li>
  * <li> Or add the following code at a given point to dump a snapshot of
  *      the native calls done until that point.
- *      <code><pre>
+ *      <pre>
  *      stats.snapshot().dump(System.out);
- *      </pre></code>
+ *      </pre>
  * </li>
  * </ol>
  * 


### PR DESCRIPTION
With these changes the project seems to build with JDK 8, with the exception of the website which has additional Scala-related issues.

JDK 8 support is necessary because trying to use the currently released hawtJNI on a project built with Java 8 provokes an ArrayIndexOutOfBounds exception from ASM.
