### PR TITLE
Add a simple method for users to customize the Windows build

### DIFF
--- a/maven-hawtjni-plugin/src/main/java/org/fusesource/hawtjni/maven/GenerateMojo.java
+++ b/maven-hawtjni-plugin/src/main/java/org/fusesource/hawtjni/maven/GenerateMojo.java
@@ -243,8 +243,10 @@ public class GenerateMojo extends AbstractMojo {
             if( "detect".equals(tool) ) {
                 copyTemplateResource("vs2008.vcproj", true);
                 copyTemplateResource("vs2010.vcxproj", true);
+                copyTemplateResource("vs2010.custom.props", true);
             } else if( "msbuild".equals(tool) ) {
                 copyTemplateResource("vs2010.vcxproj", true);
+                copyTemplateResource("vs2010.custom.props", true);
             } else if( "vcbuild".equals(tool) ) {
                 copyTemplateResource("vs2008.vcproj", true);
             } else if( "none".equals(tool) ) {

--- a/maven-hawtjni-plugin/src/main/resources/project-template/vs2010.custom.props
+++ b/maven-hawtjni-plugin/src/main/resources/project-template/vs2010.custom.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+  # This is just a stub.  If you wish to customize your vs2010.vcxproj
+  # just copy this file to src/main/native-package/vs2010.custom.props
+  # then replace add your msbuild statements here.
+  <PropertyGroup>
+  	<AdditionalIncludeDirectories>example;dirs;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+  	<AdditionalDependencies>example;lib;files;%(AdditionalDependencies)</AdditionalDependencies>
+  </PropertyGroup>
+  -->
+</Project>

--- a/maven-hawtjni-plugin/src/main/resources/project-template/vs2010.custom.props
+++ b/maven-hawtjni-plugin/src/main/resources/project-template/vs2010.custom.props
@@ -4,9 +4,13 @@
   # This is just a stub.  If you wish to customize your vs2010.vcxproj
   # just copy this file to src/main/native-package/vs2010.custom.props
   # then replace add your msbuild statements here.
-  <PropertyGroup>
-  	<AdditionalIncludeDirectories>example;dirs;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-  	<AdditionalDependencies>example;lib;files;%(AdditionalDependencies)</AdditionalDependencies>
-  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir)\my-headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(ProjectDir)\libmylibrary.a;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   -->
 </Project>

--- a/maven-hawtjni-plugin/src/main/resources/project-template/vs2010.vcxproj
+++ b/maven-hawtjni-plugin/src/main/resources/project-template/vs2010.vcxproj
@@ -73,6 +73,7 @@
     <IntDir Condition="'$(Configuration)|$(Platform)'=='debug|x64'">$(ProjectDir)/target/$(Platform)-$(Configuration)/obj\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='debug|x64'">true</LinkIncremental>
   </PropertyGroup>
+  <Import Project="vs2010.custom.props" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(JAVA_HOME)\include;$(JAVA_HOME)\include\win32;$(ProjectDir)\src\windows;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
A hawtjni user can write a custom.m4 on *nix systems, but there is no Windows equivalent unless they take the nuclear option and copy+paste Hawtjni's whole *.vcxproj into their own tree. This hooking mechanism will instead let them write a MSBuild script to do a bit of customization should it be necessary for their particular library.
