### PR TITLE
Ensure absolute path is used for library extraction and loading

### DIFF
--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java
@@ -262,6 +262,9 @@ public class Library {
 
     private File extract(ArrayList<String> errors, URL source, String prefix, String suffix, File directory) {
         File target = null;
+        if (directory != null) {
+          directory = directory.getAbsoluteFile();
+        }
         try {
             FileOutputStream os = null;
             InputStream is = null;


### PR DESCRIPTION
[`System#load`](http://docs.oracle.com/javase/7/docs/api/java/lang/System.html#load%28java.lang.String%29) requires an absolute path.  If the extraction
directory (`library.${name}.path` or `java.io.tmpdir`) is relative, the
extraction will succeed, but the `System#load` call will fail, resulting
in the library not being loaded.  This commit rectifies that by
obtaining the absolute path to the directory before extracting.  Now,
the extracted file will be referred to by its absolute path, which
should make the `System#load` call succeed.
