### PR TITLE
Improve FreeBSD support

### DIFF
--- a/maven-hawtjni-plugin/src/main/resources/project-template/m4/jni.m4
+++ b/maven-hawtjni-plugin/src/main/resources/project-template/m4/jni.m4
@@ -64,6 +64,7 @@ AC_DEFUN([WITH_JNI_JDK],
       AS_IF(test -z "$JNI_JDK", [
         case "$host_os" in
            darwin*) __JNI_GUESS="/System/Library/Frameworks/JavaVM.framework";;
+          freebsd*) __JNI_GUESS=$(env JAVAVM_DRYRUN=yes /usr/local/bin/java | grep '^JAVA_HOME' | cut -c11-);;
                  *) __JNI_GUESS="/usr";;
         esac
         AC_MSG_NOTICE([Taking a guess as to where your OS installs the JDK by default...])
@@ -107,7 +108,7 @@ AC_DEFUN([CHECK_JNI_JDK],[
     __JNI_CFLAGS="-I$__JNI_INCLUDE"
     case "$host_os" in
        darwin*) __JNI_INCLUDE_EXTRAS="darwin";;
-         bsdi*) __JNI_INCLUDE_EXTRAS="bsdos";;
+      freebsd*) __JNI_INCLUDE_EXTRAS="freebsd";;
         linux*) __JNI_INCLUDE_EXTRAS="linux genunix";;
           osf*) __JNI_INCLUDE_EXTRAS="alpha";;
       solaris*) __JNI_INCLUDE_EXTRAS="solaris";;


### PR DESCRIPTION
* Detect JAVA_HOME automatically as advised by [`man javavm`](https://www.freebsd.org/cgi/man.cgi?query=javavm&apropos=0&sektion=0&manpath=FreeBSD+10.3-RELEASE+and+Ports&arch=default&format=html#EXAMPLES) if not set
* Avoid a compile-time error on FreeBSD 10.3-RELEASE along with clang if the
  OS-specific include directory is not passed to the preprocessor, BSD/OS is dead for 15 years+ and does not correspond to modern BSDs like FreeBSD or OpenBSD. See [`config.sub`](https://github.com/gcc-mirror/gcc/blob/master/config.guess#L824).

Both compiles now perfectly on FreeBSD 9 and 10 in 32 bit and 64 bit, Java 7 and Java 8.

Error with `clang` (FreeBSD clang version 3.4.1 (tags/RELEASE_34/dot1-final 208032) 20140512, Target: x86_64-unknown-freebsd10.3, Thread model: posix):

    configure:11640: JAVA_HOME was set, checking to see if it's a JDK we can use...
    configure:11645: checking if '/usr/local/openjdk8' is a JDK
    configure:11706: cc -c -g -O2  -I/usr/local/openjdk8/include conftest.c >&5
    In file included from conftest.c:21:
    /usr/local/openjdk8/include/jni.h:45:10: fatal error: 'jni_md.h' file not found
    #include "jni_md.h"
             ^
    1 error generated.
    configure:11706: $? = 1
    
Working library:

    $ file ./target/native-build/target/lib/libjansi-1.7-SNAPSHOT.so
    ./target/native-build/target/lib/libjansi-1.7-SNAPSHOT.so: ELF 64-bit LSB shared object, x86-64, version 1 (FreeBSD), dynamically linked, not stripped