### PR TITLE
Add 10.13 in OSX SDK version list

### DIFF
--- a/hawtjni-maven-plugin/src/main/resources/project-template/m4/osx-universal.m4
+++ b/hawtjni-maven-plugin/src/main/resources/project-template/m4/osx-universal.m4
@@ -53,7 +53,7 @@ AC_DEFUN([WITH_OSX_UNIVERSAL],
     ],[
       OSX_SDKS_DIR=""
       OSX_VERSION=""
-      for v in 10.0 10.1 10.2 10.3 10.4 10.5 10.6 10.7 10.8 10.9 10.10 10.11 10.12; do
+      for v in 10.0 10.1 10.2 10.3 10.4 10.5 10.6 10.7 10.8 10.9 10.10 10.11 10.12 10.13; do
         for location in "/Developer/SDKs" "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs" ; do
           if test -z "${OSX_VERSION}" && test -d "${location}/MacOSX${v}.sdk" ; then 
             OSX_SDKS_DIR="${location}"


### PR DESCRIPTION
Solves an issue where standard library headers aren't found during compilation on OSX 10.13