### PR TITLE
Bugfixes in `StructsGenerator` and an extended `JniField` accessor model

### DIFF
--- a/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/NativesGenerator.java
+++ b/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/NativesGenerator.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.fusesource.hawtjni.generator.model.JNIClass;
 import org.fusesource.hawtjni.generator.model.JNIField;
+import org.fusesource.hawtjni.generator.model.JNIFieldAccessor;
 import org.fusesource.hawtjni.generator.model.JNIMethod;
 import org.fusesource.hawtjni.generator.model.JNIParameter;
 import org.fusesource.hawtjni.generator.model.JNIType;
@@ -189,9 +190,7 @@ public class NativesGenerator extends JNIGenerator {
             boolean allowConversion = !type.equals(type64);
             
             String simpleName = type.getSimpleName();
-            String accessor = field.getAccessor();
-            if (accessor == null || accessor.length() == 0)
-                accessor = field.getName();
+            JNIFieldAccessor accessor = field.getAccessor();
 
             String fieldId = "(*env)->GetStaticFieldID(env, that, \""+field.getName()+"\", \""+type.getTypeSignature(allowConversion)+"\")";
             if (isCPP) {
@@ -208,7 +207,7 @@ public class NativesGenerator extends JNIGenerator {
                 if( field.isPointer() ) {
                     output("(intptr_t)");
                 }
-                output(accessor);
+                output(accessor.getter());
                 output(");");
                 
             } else if (type.isArray()) {
@@ -238,7 +237,7 @@ public class NativesGenerator extends JNIGenerator {
                     } else {
                         output("ArrayRegion(env, lpObject1, 0, sizeof(");
                     }
-                    output(accessor);
+                    output(accessor.getter());
                     output(")");
                     if (!componentType.isType("byte")) {
                         output(" / sizeof(");
@@ -248,7 +247,7 @@ public class NativesGenerator extends JNIGenerator {
                     output(", (");
                     output(type.getTypeSignature4(allowConversion, false));
                     output(")");
-                    output(accessor);
+                    output(accessor.getter());
                     outputln(");");
                     output("\t}");
                 } else {
@@ -268,7 +267,7 @@ public class NativesGenerator extends JNIGenerator {
                 output("\tif (lpObject1 != NULL) set");
                 output(simpleName);
                 output("Fields(env, lpObject1, &lpStruct->");
-                output(accessor);
+                output(accessor.getter());
                 outputln(");");
                 output("\t}");
             }

--- a/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/StructsGenerator.java
+++ b/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/StructsGenerator.java
@@ -165,13 +165,14 @@ public class StructsGenerator extends JNIGenerator {
         outputln("_FID_CACHE {");
         outputln("\tint cached;");
         outputln("\tjclass clazz;");
-        output("\tjfieldID ");
         List<JNIField> fields = clazz.getDeclaredFields();
         boolean first = true;
         for (JNIField field : fields) {
             if (ignoreField(field))
                 continue;
-            if (!first)
+            if (first)
+                output("\tjfieldID ");
+            else
                 output(", ");
             output(field.getName());
             first = false;

--- a/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/model/JNIField.java
+++ b/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/model/JNIField.java
@@ -27,7 +27,7 @@ public interface JNIField {
     public JNIType getType64();
 
     public JNIClass getDeclaringClass();
-    public String getAccessor();
+    public JNIFieldAccessor getAccessor();
     public String getCast();
     public String getConditional();
     public boolean ignore();

--- a/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/model/JNIFieldAccessor.java
+++ b/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/model/JNIFieldAccessor.java
@@ -1,0 +1,19 @@
+package org.fusesource.hawtjni.generator.model;
+
+/**
+ * @author <a href="mailto:calin.iorgulescu@gmail.com">Calin Iorgulescu</a>
+ */
+public interface JNIFieldAccessor {
+    public String getter();
+
+    public String setter();
+
+    public boolean isNonMemberGetter();
+
+    public boolean isNonMemberSetter();
+
+    public boolean isMethodGetter();
+
+    public boolean isMethodSetter();
+
+}

--- a/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/model/ReflectFieldAccessor.java
+++ b/hawtjni-generator/src/main/java/org/fusesource/hawtjni/generator/model/ReflectFieldAccessor.java
@@ -1,0 +1,48 @@
+package org.fusesource.hawtjni.generator.model;
+
+/**
+ * @author <a href="mailto:calin.iorgulescu@gmail.com">Calin Iorgulescu</a>
+ */
+public class ReflectFieldAccessor implements JNIFieldAccessor {
+
+    private String getter;
+    private String setter;
+    private boolean nonMemberGetter;
+    private boolean nonMemberSetter;
+
+    public ReflectFieldAccessor(String value) {
+       this.getter = this.setter = value;
+       this.nonMemberGetter = this.nonMemberSetter = false;
+    }
+
+    public ReflectFieldAccessor(String getter, boolean nonMemberGetter, String setter, boolean nonMemberSetter) {
+        this.getter = getter;
+        this.nonMemberGetter = nonMemberGetter;
+        this.setter = setter;
+        this.nonMemberSetter = nonMemberSetter;
+    }
+
+    public String getter() {
+        return getter;
+    }
+
+    public String setter() {
+        return setter;
+    }
+
+    public boolean isNonMemberGetter() {
+        return nonMemberGetter;
+    }
+
+    public boolean isNonMemberSetter() {
+        return nonMemberSetter;
+    }
+
+    public boolean isMethodGetter() {
+        return getter.contains("(");
+    }
+
+    public boolean isMethodSetter() {
+        return setter.contains("(");
+    }
+}

--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/FieldFlag.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/FieldFlag.java
@@ -31,5 +31,22 @@ public enum FieldFlag {
      * Indicate that the field is a pointer.
      */
     POINTER_FIELD,
-    
+
+    /**
+     * Indicate that the getter method used is not part of
+     * the structure. Useful for using wrappers to access
+     * certain structure fields.
+     *
+     * Only useful when the getter is declared explicitly.
+     */
+    GETTER_NONMEMBER,
+
+    /**
+     * Indicate that the setter method used is not part of
+     * the structure. Useful for using wrappers to access
+     * certain structure fields.
+     *
+     * Only useful when the setter is declared explicitly.
+     */
+    SETTER_NONMEMBER,
 }

--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/JniField.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/JniField.java
@@ -27,6 +27,8 @@ public @interface JniField {
 
     String cast() default "";
     String accessor() default "";
+    String getter() default "";
+    String setter() default "";
     String conditional() default "";
     FieldFlag[] flags() default {};
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.6.1</version>
           <configuration>
-            <source>1.5</source>
-            <target>1.5</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
### Bugfixes

- An empty field declaration would be created in the FID cache if only skipped/ignored fields are declared in a `JniClass`.
- A `JniClass` extending another class that has only ignored fields would generate calls to `cacheSuperFields()`, `getSuperFields()`, and `setSupperFields()` despite these methods not being generated.

### Extended `JniField` accessor model

In some situations, the implementation of underlying C++ classes may restrict access to inner fields (marking them either `private` or `protected`) while providing some getter/setter-like methods to update these fields. Without loss of generality, support for interacting with these fields via existing APIs seems desirable. This patch provides the following:

- A way to provide separate `getter`/`setter` accessors for individual fields, while maintaining backwards compatibility with the `accessor` annotation.
- Support for external wrappers by specifying that the accessors are not necessarily part of the structure. This is signaled by two new `FieldFlag`s: `GETTER_NONMEMBER` and `SETTER_NONMEMBER`.

