### PR TITLE
Add support for OpenBSD by adding JNI extras directory

### DIFF
--- a/hawtjni-maven-plugin/src/main/resources/project-template/m4/jni.m4
+++ b/hawtjni-maven-plugin/src/main/resources/project-template/m4/jni.m4
@@ -110,6 +110,7 @@ AC_DEFUN([CHECK_JNI_JDK],[
        darwin*) __JNI_INCLUDE_EXTRAS="darwin";;
       freebsd*) __JNI_INCLUDE_EXTRAS="freebsd";;
         linux*) __JNI_INCLUDE_EXTRAS="linux genunix";;
+      openbsd*) __JNI_INCLUDE_EXTRAS="openbsd";;
           osf*) __JNI_INCLUDE_EXTRAS="alpha";;
       solaris*) __JNI_INCLUDE_EXTRAS="solaris";;
         mingw*) __JNI_INCLUDE_EXTRAS="win32";;


### PR DESCRIPTION
Sourcehut now offers OpenBSD images, so if there's concern about continuous integration needs I can also add a sourcehut [build manifest](https://github.com/voutilad/hawtjni-openbsd/blob/master/.build.yml) to the PR.

See https://builds.sr.ht/~voutilad/hawtjni-openbsd as an example.