### PR TITLE
fix issue where bitModel could not be retrieved on GraalVM

### DIFF
--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java
@@ -172,6 +172,11 @@ public class Library {
         if( prop!=null ) {
             return Integer.parseInt(prop);
         }
+        // GraalVM support, see https://github.com/fusesource/jansi/issues/162
+        String arch = System.getProperty("os.arch");
+        if (arch.endsWith("64") && "Substrate VM".equals(System.getProperty("java.vm.name"))) {
+            return 64;
+        }
         return -1; // we don't know..
     }
 


### PR DESCRIPTION
This PR fixes an issue in the `Library.getBitModel()` method when running in a GraalVM native image.

Non-standard system properties `sun.arch.data.model` and `com.ibm.vm.bitmode` are not available in Substrate VM (GraalVM native images). Without this fix, the `Library.getBitModel()` method always returns `-1`, and the `extractAndLoad` method never succeeds, even if the native library is available as a resource in the GraalVM native image.

This PR partly addresses https://github.com/fusesource/jansi/issues/162 ; the other part is addressed by https://github.com/fusesource/jansi-native/pull/21 .
