### PR TITLE
Fix file extraction of "one platform" libraries

### DIFF
--- a/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java
+++ b/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java
@@ -307,7 +307,7 @@ public class Library {
     }
 
     private boolean extractAndLoad(ArrayList<Throwable> errors, String customPath, String dir, String libName, String targetLibName) {
-        String resourcePath = "META-INF/native/" + ( dir == null ? "" : (dir + '/')) + libName;
+        String resourcePath = "META-INF/native/" + ( dir == "." ? "" : (dir + '/')) + libName;
         URL resource = classLoader.getResource(resourcePath);
         if( resource !=null ) {
 


### PR DESCRIPTION
> Search directories for library:
> * `${platform}/${arch}` to enable platform JNI library for different processor archs
> * `${platform}` to enable platform JNI library
> * `${os}` to enable OS JNI library
> * no directory (`"."`)

In the last case, the following fails to locate the file inside the JAR (in some JVMs?):
`URL resource = ClassLoader.getResource("META-INF/native/./lib<name>.so");`

When the classpath is not a JAR it works as expected.

```
$ java --version
openjdk 11.0.10 2021-01-19
OpenJDK Runtime Environment (build 11.0.10+9-Ubuntu-0ubuntu1.18.04)
OpenJDK 64-Bit Server VM (build 11.0.10+9-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)
```